### PR TITLE
fix: :bug: Book titles now show edition title, not user book title

### DIFF
--- a/components/book/page/Title.vue
+++ b/components/book/page/Title.vue
@@ -1,5 +1,5 @@
 <template>
-  <h1 class="book-page__title">{{ userBook.title }}</h1>
+  <h1 class="book-page__title">{{ book.title }}</h1>
 </template>
 
 <script>
@@ -9,9 +9,10 @@ import { useBookStore } from "~/store/BookStore";
 export default {
   setup() {
     const bookStore = useBookStore();
-    const { userBook } = storeToRefs(bookStore);
+    const { book, userBook } = storeToRefs(bookStore);
 
     return {
+      book,
       userBook,
     };
   },

--- a/pages/books/[id].vue
+++ b/pages/books/[id].vue
@@ -1,6 +1,6 @@
 <template>
   <div class="book-page d-flex jc-center">
-    <Title>{{ userBook ? userBook.title : book.title }}</Title>
+    <Title v-if="book?.title">{{ book.title }}</Title>
 
     <div class="book-page__content w-100">
       <div class="d-flex flex-column gap-half">


### PR DESCRIPTION
Book titles were not displaying for signed out users because that value was trying to pull from user_books. Updated to pull from the edition title.